### PR TITLE
Add local-address for configuration of localAddress in requests

### DIFF
--- a/config-defs.js
+++ b/config-defs.js
@@ -7,6 +7,7 @@ var path = require("path")
   , semver = require("semver")
   , stableFamily = semver.parse(process.version)
   , nopt = require("nopt")
+  , os = require('os')
   , osenv = require("osenv")
 
 try {
@@ -168,6 +169,7 @@ Object.defineProperty(exports, "defaults", {get: function () {
     , "init.author.url" : ""
     , json: false
     , link: false
+    , "local-address" : undefined
     , loglevel : "http"
     , logstream : process.stderr
     , long : false
@@ -258,6 +260,18 @@ exports.types =
   , "init.author.url" : ["", url]
   , json: Boolean
   , link: Boolean
+  // local-address must be listed as an IP for a local network interface
+  // must be IPv4 due to node bug
+  , "local-address" : Object.keys(os.networkInterfaces()).map(function (nic) {
+                   return os.networkInterfaces()[nic].filter(function (addr) {
+                    return addr.family === "IPv4"
+                   })
+                   .map(function (addr) {
+                     return addr.address
+                   })
+                 }).reduce(function (curr, next) {
+                  return curr.concat(next)
+                 }, [])
   , loglevel : ["silent","win","error","warn","http","info","verbose","silly"]
   , logstream : Stream
   , long : Boolean

--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
     "config-chain": "~1.1.1",
     "inherits": "~1.0.0",
     "once": "~1.1.1",
-    "mkdirp": "~0.3.3"
+    "mkdirp": "~0.3.3",
+    "semver": "~1.0.14",
+    "osenv": "0.0.3",
+    "ini": "~1.0.4"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
This should aid in setting up which network interface npm is using to send out requests, due to a bug https://github.com/joyent/node/issues/3892 it is limited to IPv4 addresses.

related: https://github.com/isaacs/npm-registry-client/pull/7
