### PR TITLE
Set empty string as default browser

### DIFF
--- a/config-defs.js
+++ b/config-defs.js
@@ -105,10 +105,7 @@ Object.defineProperty(exports, "defaults", {get: function () {
   return defaults =
     { "always-auth" : false
 
-      // are there others?
-    , browser : process.platform === "darwin" ? "open"
-              : process.platform === "win32" ? "start"
-              : "google-chrome"
+    , browser : ""
 
     , ca : // the npm CA certificate.
       "-----BEGIN CERTIFICATE-----\n"+


### PR DESCRIPTION
If npm will use Opener to to get web pages, it needn't to set default browser.

references to https://github.com/isaacs/npm/pull/2742
