### PR TITLE
Adding bin-links option

### DIFF
--- a/config-defs.js
+++ b/config-defs.js
@@ -113,7 +113,7 @@ Object.defineProperty(exports, "defaults", {get: function () {
 
   return defaults =
     { "always-auth" : false
-
+    , "bin-links" : true
     , browser : null
 
     , ca : // the npm CA certificate.
@@ -272,6 +272,7 @@ Object.defineProperty(exports, "defaults", {get: function () {
 
 exports.types =
   { "always-auth" : Boolean
+  , "bin-links": Boolean
   , browser : [null, String]
   , ca: [null, String, Array]
   , cache : path


### PR DESCRIPTION
Adding "bin-links" option to support isaacs/npm#3090. Setting it to false will prevent npm from making any symlinks to binaries when using the "npm install" or "npm link" commands.
