### PR TITLE
Added missing semver dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "once": "~1.1.1",
     "mkdirp": "~0.3.3",
     "osenv": "0.0.3",
-    "nopt": "2"
+    "nopt": "2",
+    "semver": "~1.1.0"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
config-defs.js requires semver but the module is not listed in npmconf's `package.json`. This is probably not an issue with the way npm uses it but it's causing a problem when using npmconf and npm-registry-client separately. I added the same version used by npm-registry-client.
