### PR TITLE
Add `--version-prefix`

### DIFF
--- a/config-defs.js
+++ b/config-defs.js
@@ -351,6 +351,7 @@ exports.types =
   , userignorefile : path
   , umask: Octal
   , version : Boolean
+  , "version-prefix": String
   , versions : Boolean
   , viewer: String
   , yes: [false, null, Boolean]


### PR DESCRIPTION
Related to "Add ability to change 'v' prefix when tagging with `npm version`" https://github.com/isaacs/npm/pull/3331
