### PR TITLE
Added tap to devDependencies so npm i/npm test works

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "semver": "2",
     "ini": "~1.1.0"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "tap": "~0.4.0"
+  },
   "scripts": {
     "test": "tap test/*.js"
   },


### PR DESCRIPTION
`tap` was not listed in the `devDependencies` for this module so a standard `npm install; npm test` will fail.
