### PR TITLE
Add --ninja as an alias for --force

### DIFF
--- a/config-defs.js
+++ b/config-defs.js
@@ -426,6 +426,7 @@ exports.shorthands =
   , f : ["--force"]
   , gangster : ["--force"]
   , gangsta : ["--force"]
+  , ninja : ["--force"]
   , desc : ["--description"]
   , "no-desc" : ["--no-description"]
   , "local" : ["--no-global"]


### PR DESCRIPTION
On the unfailing advivce of @rvagg, I'd like to propose an additional alias. `--force` publish should be used with care, no doubt. But when it's done, style always helps.

As an etymological note, I'm playing off the term "ninja edit", used on the Internet to indicate a change to a resource that was linked or referenced where the change was made before the original version of the resource was ever accessed.
