### PR TITLE
Ignore errors when unlinking empty (or non-existing) npmrc

### DIFF
--- a/npmconf.js
+++ b/npmconf.js
@@ -228,9 +228,12 @@ Conf.prototype.save = function (where, cb) {
   this._saving ++
 
   var mode = where === 'user' ? 0600 : 0666
-  if (!data.trim())
-    fs.unlink(target.path, done)
-  else {
+  if (!data.trim()) {
+    fs.unlink(target.path, function (er) {
+      // ignore the possible error (e.g. the file doesn't exist)
+      done(null)
+    })
+  } else {
     mkdirp(path.dirname(target.path), function (er) {
       if (er)
         return then(er)


### PR DESCRIPTION
This should fix (at least) npm/npm#5065, npm/npm#5160, and npm/npm#5223.
