### PR TITLE
revert to ~

### DIFF
--- a/config-defs.js
+++ b/config-defs.js
@@ -189,7 +189,7 @@ Object.defineProperty(exports, "defaults", {get: function () {
     , "save-dev" : false
     , "save-exact" : false
     , "save-optional" : false
-    , "save-prefix": "^"
+    , "save-prefix": "~"
     , searchopts: ""
     , searchexclude: null
     , searchsort: "name"


### PR DESCRIPTION
1. `^` is not supported in earlier versions of node, most notably none of the 0.8 series supports it. This has been **very** premature and has made it very difficult, bordering on impossible, to ensure libraries are still compatible with 0.8, particularly through CI (travis, etc.). None of _us_ may be using 0.8 but there are plenty of deployments in the wild with 0.8 that are using open source libraries where we are having to switch off CI for testing. As `^` spreads rapidly like a virus through open source libraries the breakage is getting out of hand. This is bad for Node and bad for the community.
2. This has been brute-force social engineering to attempt to shift the entire Node community over to "proper semver". It's been too sudden and the messaging has been mostly absent. Too many of us are still stuck in the traditional Node reading of semver where minor versions are the ones that matter for breakage. Many of us are seeing breakage in production deploys due to downstream libraries _not_ following the major-for-breakage rules. This is also very bad for Node and bad for the community. It makes Node more prone to breakage and makes the highly-modular nature of the Node ecosystem more fragile and easier to dismiss as a new approach to application design.
