### PR TITLE
reinstate support for upper-case npm_config_* environment variables

### DIFF
--- a/npmconf.js
+++ b/npmconf.js
@@ -338,7 +338,8 @@ Conf.prototype.addEnv = function (env) {
 
       // leave first char untouched, even if
       // it is a "_" - convert all other to "-"
-      var p = k.replace(/^npm_config_/, '')
+      var p = k.toLowerCase()
+               .replace(/^npm_config_/, '')
                .replace(/(?!^)_/g, '-')
       conf[p] = env[k]
     })

--- a/test/00-setup.js
+++ b/test/00-setup.js
@@ -15,15 +15,18 @@ process.env.npm_config_userconfig = exports.userconfig
 process.env.npm_config_other_env_thing = 1000
 process.env.random_env_var = 'asdf'
 process.env.npm_config__underbar_env_thing = 'underful'
+process.env.NPM_CONFIG_UPPERCASE_ENV_THING = 42
 
 exports.envData = {
   userconfig: exports.userconfig,
   '_underbar-env-thing': 'underful',
+  'uppercase-env-thing': '42',
   'other-env-thing': '1000'
 }
 exports.envDataFix = {
   userconfig: exports.userconfig,
   '_underbar-env-thing': 'underful',
+  'uppercase-env-thing': 42,
   'other-env-thing': 1000,
 }
 


### PR DESCRIPTION
This fixes a regression introduced in e5dcca4.
