### PR TITLE
Remove "win" from allowed loglevel types

### DIFF
--- a/config-defs.js
+++ b/config-defs.js
@@ -266,7 +266,7 @@ exports.types =
   // local-address must be listed as an IP for a local network interface
   // must be IPv4 due to node bug
   , "local-address" : getLocalAddresses()
-  , loglevel : ["silent","win","error","warn","http","info","verbose","silly"]
+  , loglevel : ["silent","error","warn","http","info","verbose","silly"]
   , logstream : Stream
   , long : Boolean
   , message: String


### PR DESCRIPTION
Removing the "win" loglevel from the allowed types

It's no longer supported and displays the same output as "silly". See more at https://github.com/npm/npm/issues/5038#issuecomment-49494859
