### PR TITLE
Ignore missing directory error.

### DIFF
--- a/lib/set-user.js
+++ b/lib/set-user.js
@@ -20,6 +20,9 @@ function setUser (cb) {
 
   var prefix = path.resolve(this.get("prefix"))
   fs.stat(prefix, function (er, st) {
+    //if the config path doesn't exist, ignore the error
+    if (er && er.code === 'ENOENT') return cb();
+    
     defaultConf.user = st && st.uid
     return cb(er)
   })


### PR DESCRIPTION
Ignore the `ENOENT` error for a path that doesn't exist... this will correct the issues regarding...

fixes https://github.com/joyent/node/issues/8117

When the error is ignored here, the directory will be properly created/handled elsewhere in code.
