### PR TITLE
coerce --tag config to a string before calling .trim()

### DIFF
--- a/config-defs.js
+++ b/config-defs.js
@@ -41,7 +41,7 @@ function validateSemver (data, k, val) {
 }
 
 function validateTag (data, k, val) {
-  val = val.trim()
+  val = ('' + val).trim()
   if (!val || semver.validRange(val)) return false
   data[k] = val
 }


### PR DESCRIPTION
Tiny thing to make `--no-tag` not crash.  (Not that it does anything useful ANYWAY, but that's another matter.)
