### PR TITLE
Honor setting `cache` path via environment variable.

### DIFF
--- a/config-defs.js
+++ b/config-defs.js
@@ -104,7 +104,7 @@ else home = path.resolve(temp, "npm-" + uidOrPid)
 
 var cacheExtra = process.platform === "win32" ? "npm-cache" : ".npm"
 var cacheRoot = process.platform === "win32" && process.env.APPDATA || home
-var cache = path.resolve(cacheRoot, cacheExtra)
+var cache = process.env.NPM_CONFIG_CACHE ? process.env.NPM_CONFIG_CACHE : path.resolve(cacheRoot, cacheExtra)
 
 
 var globalPrefix

--- a/test/cache.js
+++ b/test/cache.js
@@ -1,0 +1,14 @@
+var test = require('tap').test
+var npmconf = require('../npmconf.js')
+var common = require('./00-setup.js')
+
+test('cache path can be set via environment variable', function (t) {
+  process.env.NPM_CONFIG_CACHE = '/tmp/npmcache'
+
+  npmconf.load({}, common.builtin, function (er, conf) {
+    if (er) throw er
+    t.equal(conf.get('cache'), '/tmp/npmcache')
+    t.end()
+  })
+})
+


### PR DESCRIPTION
Before this change, typing `npm config get cache` would result in `$HOME/.npm` even with `NPM_CONFIG_CACHE` set to some explicit path.
