### PR TITLE
Fix broken getLocalAddresses

### DIFF
--- a/config-defs.js
+++ b/config-defs.js
@@ -329,8 +329,17 @@ exports.types =
   }
 
 function getLocalAddresses() {
-  Object.keys(os.networkInterfaces()).map(function (nic) {
-    return os.networkInterfaces()[nic].filter(function (addr) {
+  var interfaces
+  // https://github.com/npm/npm/issues/8094: some environments require elevated permissions to enumerate
+  // interfaces, and synchronously throw EPERM when run without
+  // elevated privileges
+  try {
+    interfaces = os.networkInterfaces()
+  } catch (e) {
+    interfaces = {}
+  }
+  Object.keys(interfaces).map(function (nic) {
+    return interfaces[nic].filter(function (addr) {
       return addr.family === "IPv4"
     })
     .map(function (addr) {


### PR DESCRIPTION
On some locked-down systems (Docker in QEMU in my case), `os.networkInterfaces()` can throw an EAFNOSUPPORT error.

``` bash
root@8e3c8f0809de:/npmconf# npm test
npm info it worked if it ends with ok
npm info using npm@3.3.12
npm info using node@v5.1.0
npm info lifecycle npmconf@2.1.2~pretest: npmconf@2.1.2
npm info lifecycle npmconf@2.1.2~test: npmconf@2.1.2

> npmconf@2.1.2 test /npmconf
> tap test/*.js

test/00-setup.js ...................................... 1/1 2s
/npmconf/config-defs.js:332
  Object.keys(os.networkInterfaces()).map(function (nic) {
                 ^

Error: EAFNOSUPPORT: address family not supported, uv_interface_addresses
    at Error (native)
    at getLocalAddresses (/npmconf/config-defs.js:332:18)
    at Object.<anonymous> (/npmconf/config-defs.js:281:23)
    at Module._compile (module.js:425:26)
    at Object.Module._extensions..js (module.js:432:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:313:12)
    at Module.require (module.js:366:17)
    at require (module.js:385:17)
    at Object.<anonymous> (/npmconf/npmconf.js:4:18)
test/basic.js ......................................... 0/1
```

This was addressed in `npm` with https://github.com/npm/npm/commit/a4b62387b41848818973eeed056fd5c6570274f3 but not in `npmconf`.

This patch apply the same fix to `npmconf`.

With the fix:

``` bash
root@8e3c8f0809de:/npmconf# npm test
npm info it worked if it ends with ok
npm info using npm@3.3.12
npm info using node@v5.1.0
npm info lifecycle npmconf@2.1.2~pretest: npmconf@2.1.2
npm info lifecycle npmconf@2.1.2~test: npmconf@2.1.2

> npmconf@2.1.2 test /npmconf
> tap test/*.js

test/00-setup.js ...................................... 1/1 2s
test/basic.js ......................................... 7/7 3s
test/builtin.js ....................................... 7/7 3s
test/certfile.js ...................................... 2/2 3s
test/credentials.js ................................. 29/29
test/project.js ....................................... 7/7 3s
test/save.js .......................................... 3/3 3s
test/semver-tag.js .................................... 2/2 3s
total ............................................... 58/58

  58 passing (25s)

  ok
npm info lifecycle npmconf@2.1.2~posttest: npmconf@2.1.2
npm info ok
root@8e3c8f0809de:/npmconf#
```
